### PR TITLE
Lead README with stock `dsh plugin add` for 0.1.5-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Stock install is `dsh plugin --profile web add github:aa2246740/dsh-watcher` (pnpm on PATH, then restart the Host and reload). `dsh.bundle.patch` and committed `lib/` make that git spec boot without a `prepare` script.
+
 - Opening Watcher now restores every older conversation Turn automatically through RC8's public Session paging API. Normal use has no manual "load all" step; paging progress is passive, and a retry appears only when the official loader is busy or cannot advance.
 - Added whole-session Turn/Step projections so the progressive UI can show loaded-versus-total evidence while RC8 pages arrive.
 

--- a/README.en.md
+++ b/README.en.md
@@ -2,6 +2,14 @@
 
 # Watcher
 
+```sh
+dsh plugin --profile web add github:aa2246740/dsh-watcher
+```
+
+You need official `dsh` (or `npx @deepseek-ai/dsh`) and **pnpm** on `PATH`. `dsh plugin add` runs pnpm in `$DSH_HOME/profiles/web` and, because this package declares `dsh.bundle.patch`, appends the bundle to that profile. Then **restart that Host and reload the page**. The command writes the profile. It does not hot-load a running process.
+
+`lib/` is committed, so a git install does not need a local build, `prepare`, or `allowBuilds`. DeepSeek Harness **0.1.5-rc.2**. Node `^22.19.0` or `>=24`.
+
 A read-only plugin for DeepSeek Harness Web. Open the eye in the session header. A Session becomes a foldable work path: how many steps ran, how many tools fired, how long it took. Open a step for parallel branches, a tool result, or a reasoning row that stays folded until you ask.
 
 It does not inject messages, invent hidden chain-of-thought, or replace the official Trajectory.
@@ -18,37 +26,34 @@ It does not inject messages, invent hidden chain-of-thought, or replace the offi
 
 Grouped view only stacks what it can prove. Two different bash calls stay apart. The model stage shows only provider-visible reasoning already written into the Session. If nothing was recorded, it says so.
 
-## Install
-
-```sh
-dsh plugin --profile web add github:aa2246740/dsh-watcher
-```
-
-Or from a clone:
+From a clone:
 
 ```sh
 git clone https://github.com/aa2246740/dsh-watcher.git
 dsh plugin --profile web add ./dsh-watcher
 ```
 
-Then restart that DSH Host and reload the page. `dsh plugin add` writes the profile. It does not hot-load a running Host.
+That path also needs pnpm, then a Host restart and page reload.
 
 ```sh
 dsh plugin --profile web remove dsh-watcher
 ```
 
-DeepSeek Harness `0.1.2-rc.1`. Node `^22.19.0` or `>=24`.
+DSH.app's `desktop` profile rejects `github:`. Use `dsh web` and install into the `web` profile.
 
 The interaction contract lives in [DESIGN.md](./DESIGN.md). MIT.
 
 ## Build from source
 
-Use a prepared DSH 0.1.2-rc.1 checkout. The plugin may live outside the Harness tree.
+Skip this for a normal install. Rebuild the committed `lib/` with **pnpm** after TypeScript changes:
 
 ```sh
+pnpm install
+pnpm test
 node scripts/link-harness-dependencies.mjs /path/to/harness
-DSHX_HARNESS=/path/to/harness npm run build
-npm test
+pnpm build
 ```
+
+`pnpm build` needs a local Harness checkout that can resolve the `@deepseek-ai/dsh-*` peers. Do not use this path to install the plugin.
 
 Watcher waits for the Chat projection on cold sessions before mounting its panel.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 # Watcher
 
+```sh
+dsh plugin --profile web add github:aa2246740/dsh-watcher
+```
+
+PATH 上需要官方 `dsh`（或 `npx @deepseek-ai/dsh`）和 **pnpm**。`dsh plugin add` 会在 `$DSH_HOME/profiles/web` 里跑 pnpm，并因为本包装了 `dsh.bundle.patch` 而写入 profile bundles。然后**重启这个 Host，再刷新页面**。它只写 profile，不会热挂正在跑的进程。
+
+仓库已提交 `lib/`，git 安装不用再构建，也不走 `prepare` / `allowBuilds`。需要 DeepSeek Harness **0.1.5-rc.2**，Node `^22.19.0` 或 `>=24`。
+
 DeepSeek Harness Web 的只读插件。点会话标题栏里的眼睛，把 Session 收成一张能折叠的工作路径：这轮走了几步、跑了几次、花了多久；再展开某一步看并行分支、工具结果，或一条默认折着的推理记录。
 
 它不往对话里塞消息，不编隐藏思维链，也不替代官方 Trajectory。
@@ -18,37 +26,34 @@ DeepSeek Harness Web 的只读插件。点会话标题栏里的眼睛，把 Sess
 
 归类只叠能证明相同的调用。两条不同的 bash 不会被捏在一起。模型阶段只显示供应商已经写进 Session 的可见 reasoning；没有记录就写未记录。
 
-## 安装
-
-```sh
-dsh plugin --profile web add github:aa2246740/dsh-watcher
-```
-
-或本地 clone：
+已经 clone 过的目录也可以：
 
 ```sh
 git clone https://github.com/aa2246740/dsh-watcher.git
 dsh plugin --profile web add ./dsh-watcher
 ```
 
-然后重启这个 DSH Host，刷新页面。`dsh plugin add` 只写 profile，不会热挂正在跑的 Host。
+同样需要 pnpm，然后重启 Host 并刷新页面。
 
 ```sh
 dsh plugin --profile web remove dsh-watcher
 ```
 
-需要 DeepSeek Harness `0.1.2-rc.1`，Node `^22.19.0` 或 `>=24`。
+DSH.app 的 `desktop` profile 不接受 `github:`。用 `dsh web` 装进 web profile。
 
 交互约定在 [DESIGN.md](./DESIGN.md)。MIT。
 
 ## 从源码构建
 
-使用已完成构建的 DSH 0.1.2-rc.1 checkout；插件可以放在独立目录。
+日常安装不用这一步。改 TypeScript 后用 **pnpm** 重建已提交的 `lib/`：
 
 ```sh
+pnpm install
+pnpm test
 node scripts/link-harness-dependencies.mjs /path/to/harness
-DSHX_HARNESS=/path/to/harness npm run build
-npm test
+pnpm build
 ```
+
+`pnpm build` 需要能解析 `@deepseek-ai/dsh-*` peer 的本机 Harness 检出。装插件不要走这条路径。
 
 冷会话的 Chat 数据尚未到达时，Watcher 显示等待提示，数据到达后再挂载面板。

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "keywords": [
     "deepseek-harness",
     "dsh",
+    "dsh-plugin",
     "watcher",
     "agent",
     "observability",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stock DeepSeek Harness **0.1.5-rc.2** users have the official CLI only. No Creator Mode, no DSHX, no `my-plugins` drop-in.

This PR makes that the documented default:

```sh
dsh plugin --profile web add github:aa2246740/dsh-watcher
```

Then restart that Host and reload the page. **pnpm** must be on `PATH` (`dsh plugin add` runs it inside `$DSH_HOME/profiles/web`).

The command already works on this tree: `dsh.bundle.patch` points at `cordis.patch.yml`, and `lib/` is committed, so a git spec does not need a `prepare` script or pnpm `allowBuilds`.

Do not merge until Cola approves.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02fa3823-e3b1-51a5-a0c7-8480166f2305?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02fa3823-e3b1-51a5-a0c7-8480166f2305&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

